### PR TITLE
Prevent a crash when creating an inline datepicker.

### DIFF
--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -334,17 +334,6 @@
 		this.$calendar.addClass(this.options.theme);
 		this.$target.after(this.$button);
 		
-		if (this.options.inline != false) {
-			this.hideObject(this.$button);
-			var $container = typeof this.options.inline === 'string' ? $('#' + this.options.inline) : this.options.inline;
-			$container.append(this.$calendar);
-			this.$calendar.css({position: 'relative', left: '0px'});
-			this.initializeDate();
-		} else {
-			this.$target.parent().after(this.$calendar);
-			this.hide(!this.options.gainFocusOnConstruction);
-		}
-		
 		// be sure parent of the calendar is positionned  to calculate the position of the calendar
 		if (this.$calendar.parent().css('position') === 'static') {
 			this.$calendar.parent().css('position', 'relative');
@@ -373,7 +362,18 @@
 		} else {
 			this.hideObject(this.$calendar.find('.datepicker-close-wrap'));
 			this.hideObject(this.$calendar.find('.datepicker-bn-close-label'));
-		}
+        }
+
+        if (this.options.inline != false) {
+            this.hideObject(this.$button);
+            var $container = typeof this.options.inline === 'string' ? $('#' + this.options.inline) : this.options.inline;
+            $container.append(this.$calendar);
+            this.$calendar.css({ position: 'relative', left: '0px' });
+            this.initializeDate();
+        } else {
+            this.$target.parent().after(this.$calendar);
+            this.hide(!this.options.gainFocusOnConstruction);
+        }
 		
 		this.keys = {
 			tab: 9,


### PR DESCRIPTION
There was a crash when creating an inline datepicker because the call "this.initializeDate()" needed a bunch of instance variables that were initialized after.