### PR TITLE
Use Shift+PageUp/PageDown to move to previous/next year

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,8 +365,8 @@ $('your date selector').datepicker({
 * <kbd>Down</kbd> Move focus to the same day of the following week. Will wrap to the appropriate day in the following month.
 * <kbd>PgUp</kbd> Move focus to the same date of the previous month. If that date does not exist, focus is placed on the last day of the month.
 * <kbd>PgDn</kbd> Move focus to the same date of the following month. If that date does not exist, focus is placed on the last day of the month.
-* <kbd>Alt+PgUp</kbd> Move focus to the same date of the previous year. If that date does not exist (e.g leap year), focus is placed on the last day of the month.
-* <kbd>Alt+PgDn</kbd> Move focus to the same date of the following year. If that date does not exist (e.g leap year), focus is placed on the last day of the month.
+* <kbd>Shift+PgUp</kbd> Move focus to the same date of the previous year. If that date does not exist (e.g leap year), focus is placed on the last day of the month.
+* <kbd>Shift+PgDn</kbd> Move focus to the same date of the following year. If that date does not exist (e.g leap year), focus is placed on the last day of the month.
 * <kbd>Home</kbd> Move to the first day of the month.
 * <kbd>End</kbd> Move to the last day of the month
 * <kbd>Tab</kbd> / <kbd>Shift+Tab</kbd> If the datepicker is in modal mode, navigate between calander grid and close/previous/next selection buttons, otherwise move to the field following/preceding the date textbox associated with the datepicker

--- a/js/datepicker.js
+++ b/js/datepicker.js
@@ -33,8 +33,8 @@
  *		- Shift+Tab - reverses the direction of the tab order. Once in the widget, a Shift+Tab will take the user to the previous focusable element in the tab order.
  *		- Up Arrow and Down Arrow - goes to the same day of the week in the previous or next week respectively. If the user advances past the end of the month they continue into the next or previous month as appropriate.
  *		- Left Arrow and Right Arrow - advances one day to the next, also in a continuum. Visually focus is moved from day to day and wraps from row to row in a grid of days and weeks.
- *		- Alt+Page Up - Moves to the same date in the previous year.
- *		- Alt+Page Down - Moves to the same date in the next year.
+ *		- Shift+Page Up - Moves to the same date in the previous year.
+ *		- Shift+Page Down - Moves to the same date in the next year.
  *		- Space -
  *			Singleton Mode: acts as a toggle either selecting or deselecting the date.
  *			Contiguous Mode: Similar to selecting a range of text. Space selects the first date. Shift+Arrows add to the selection. Pressing Space again deselects the previous selections and selects the current focused date.
@@ -1920,14 +1920,15 @@
 			case this.keys.pageup:
 				{
 					var active = this.$grid.attr('aria-activedescendant');
-					if (e.shiftKey || e.ctrlKey) {
+					if (e.altKey || e.ctrlKey) {
 						return true;
 					}
 					e.preventDefault();
 					var ok = false;
 					switch (this.gridType) {
 						case 0: // days grid
-							if (e.altKey) {
+							if (e.shiftKey) {
+								console.log('test');
 								e.stopImmediatePropagation();
 								ok = this.showDaysOfPrevYear();
 							} else {
@@ -1957,14 +1958,14 @@
 			case this.keys.pagedown:
 				{
 					var active = this.$grid.attr('aria-activedescendant');
-					if (e.shiftKey || e.ctrlKey) {
+					if (e.altKey || e.ctrlKey) {
 						return true;
 					}
 					e.preventDefault();
 					var ok = false;
 					switch (this.gridType) {
 						case 0: // days grid
-							if (e.altKey) {
+							if (e.shiftKey) {
 								e.stopImmediatePropagation();
 								ok = this.showDaysOfNextYear();
 							} else {


### PR DESCRIPTION
Use Shift+PageUp/PageDown instead of Alt+PageUp/PageDown to move to previous/next year as specified in w3c standards and examples:

- https://raw.githack.com/w3c/aria-practices/issue57-date-picker-design-pattern/aria-practices.html#calendar-grid-keyboard-interaction

- https://w3c.github.io/aria-practices/examples/dialog-modal/datepicker-dialog.html#kbd_label

Probably also update of the shortcuts in [Demo](http://eureka2.github.io/ab-datepicker/) is needed, but it seems the Demo is not part of this repository.